### PR TITLE
移除language/overrides 及後台預設版型isis 的ignore

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -352,7 +352,6 @@
 /administrator/language/en-GB/en-GB.tpl_isis.sys.ini
 /administrator/language/en-GB/en-GB.xml
 /administrator/language/en-GB/install.xml
-/administrator/language/overrides/*
 /administrator/language/index.html
 /administrator/logs/*
 /administrator/manifests/files/joomla.xml
@@ -384,7 +383,6 @@
 /administrator/modules/mod_unread/*
 /administrator/modules/mod_version/*
 /administrator/templates/hathor/*
-/administrator/templates/isis/*
 /administrator/templates/system/*
 /bin/*
 /cache/*
@@ -508,7 +506,6 @@
 /language/en-GB/en-GB.tpl_protostar.sys.ini
 /language/en-GB/en-GB.xml
 /language/en-GB/install.xml
-/language/overrides/*
 /language/index.html
 /layouts/joomla/*
 /layouts/libraries/*


### PR DESCRIPTION
因為我們會修改語言覆蓋
及偶爾後台會用版型覆蓋預設的內容